### PR TITLE
Fix `LexicalSimilarityScorer` to actually use `similarityFunc`

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -45,7 +45,7 @@ type Scorer = func(s Sample) Result
 // You can choose which similarity function to use, such as [LevenshteinDistance] or [ExactMatch].
 func LexicalSimilarityScorer(similarityFunc func(a, b string) Score) Scorer {
 	return func(sample Sample) Result {
-		score := LevenshteinDistance(sample.Expected, sample.Output)
+		score := similarityFunc(sample.Expected, sample.Output)
 		return Result{Score: score, Type: "LexicalSimilarity"}
 	}
 }

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -43,6 +43,7 @@ func TestLexicalSimilarityScorer(t *testing.T) {
 			{"a", "", 0},
 			{"", "a", 0},
 			{"a", "a", 1},
+			{"a", "ab", 0},
 		}
 		for _, test := range tests {
 			t.Run(test.expected+" "+test.output, func(t *testing.T) {


### PR DESCRIPTION
I had forgotten to change it from `LevenshteinDistance`.