### PR TITLE
Add Exec tool to enable programmatic shell command execution

### DIFF
--- a/tools/exec.go
+++ b/tools/exec.go
@@ -1,0 +1,131 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"maragu.dev/gai"
+)
+
+// ExecArgs holds the arguments for the Exec tool
+type ExecArgs struct {
+	Command string   `json:"command" jsonschema_description:"The command to execute."`
+	Args    []string `json:"args,omitempty" jsonschema_description:"Arguments to pass to the command."`
+	Input   string   `json:"input,omitempty" jsonschema_description:"Optional input to provide to stdin."`
+	Timeout int      `json:"timeout,omitempty" jsonschema_description:"Optional timeout in seconds. Default is 30 seconds."`
+}
+
+// NewExec creates a new tool for executing shell commands
+func NewExec() gai.Tool {
+	return gai.Tool{
+		Name: "exec",
+		Description: `Execute a shell command and capture its output.
+
+Executes the provided command with the specified arguments and returns the output.
+- Stdin can be provided via the input parameter
+- Timeout can be specified in seconds (default is 30 seconds)
+- Both stdout and stderr are captured and included in the output
+- Command arguments are properly escaped`,
+		Schema: gai.GenerateSchema[ExecArgs](),
+		Function: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
+			var args ExecArgs
+			if err := json.Unmarshal(rawArgs, &args); err != nil {
+				return "", fmt.Errorf("error unmarshaling exec args from JSON: %w", err)
+			}
+
+			if args.Command == "" {
+				return "", errors.New("command cannot be empty")
+			}
+
+			// Set default timeout if not provided
+			timeout := 30
+			if args.Timeout > 0 {
+				timeout = args.Timeout
+			}
+
+			// Create a context with timeout
+			execCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+			defer cancel()
+
+			// Create the command with provided arguments
+			cmd := exec.CommandContext(execCtx, args.Command, args.Args...)
+
+			// Buffer for stdout and stderr
+			var stdout, stderr bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+
+			// If input is provided, set up stdin
+			if args.Input != "" {
+				cmd.Stdin = strings.NewReader(args.Input)
+			}
+
+			// Execute the command
+			err := cmd.Run()
+
+			// Check if the error was due to the context being canceled (timeout)
+			if err != nil && execCtx.Err() == context.DeadlineExceeded {
+				return fmt.Sprintf("Command timed out after %d seconds", timeout), 
+					fmt.Errorf("command timed out after %d seconds", timeout)
+			}
+
+			// Format the output
+			var result strings.Builder
+			
+			// Add stdout if present
+			stdoutStr := stdout.String()
+			if len(stdoutStr) > 0 {
+				result.WriteString("STDOUT:\n")
+				result.WriteString(stdoutStr)
+				// Add newline if stdout doesn't end with one
+				if !strings.HasSuffix(stdoutStr, "\n") {
+					result.WriteString("\n")
+				}
+			}
+			
+			// Add stderr if present
+			stderrStr := stderr.String()
+			if len(stderrStr) > 0 {
+				if result.Len() > 0 {
+					result.WriteString("\n")
+				}
+				result.WriteString("STDERR:\n")
+				result.WriteString(stderrStr)
+				// Add newline if stderr doesn't end with one
+				if !strings.HasSuffix(stderrStr, "\n") {
+					result.WriteString("\n")
+				}
+			}
+
+			// Add error information if command failed
+			if err != nil {
+				var exitErr *exec.ExitError
+				if errors.As(err, &exitErr) {
+					if result.Len() > 0 {
+						result.WriteString("\n")
+					}
+					result.WriteString(fmt.Sprintf("Command exited with status %d\n", exitErr.ExitCode()))
+				} else {
+					if result.Len() > 0 {
+						result.WriteString("\n")
+					}
+					result.WriteString(fmt.Sprintf("ERROR: %s\n", err.Error()))
+				}
+				return result.String(), err
+			}
+
+			// If no output was generated, indicate success
+			if result.Len() == 0 {
+				result.WriteString("Command executed successfully with no output")
+			}
+
+			return result.String(), nil
+		},
+	}
+}

--- a/tools/exec_test.go
+++ b/tools/exec_test.go
@@ -1,0 +1,170 @@
+package tools_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"maragu.dev/gai/tools"
+	"maragu.dev/is"
+)
+
+func TestNewExec(t *testing.T) {
+	t.Run("successfully executes a command", func(t *testing.T) {
+		tool := tools.NewExec()
+
+		// Check tool name
+		is.Equal(t, "exec", tool.Name)
+
+		// Execute a simple echo command
+		result, err := tool.Function(t.Context(), mustMarshalJSON(tools.ExecArgs{
+			Command: "echo",
+			Args:    []string{"Hello, World!"},
+		}))
+
+		is.NotError(t, err)
+		is.True(t, strings.Contains(result, "Hello, World!"))
+	})
+
+	t.Run("handles command with stdin input", func(t *testing.T) {
+		tool := tools.NewExec()
+
+		// Execute the cat command, which reads from stdin
+		result, err := tool.Function(t.Context(), mustMarshalJSON(tools.ExecArgs{
+			Command: "cat",
+			Input:   "Input from stdin",
+		}))
+
+		is.NotError(t, err)
+		is.True(t, strings.Contains(result, "Input from stdin"))
+	})
+
+	t.Run("handles command failure", func(t *testing.T) {
+		tool := tools.NewExec()
+
+		// Execute a command that will fail
+		result, err := tool.Function(t.Context(), mustMarshalJSON(tools.ExecArgs{
+			Command: "ls",
+			Args:    []string{"/nonexistent/directory"},
+		}))
+
+		is.True(t, err != nil)
+		is.True(t, strings.Contains(result, "STDERR:"))
+		is.True(t, strings.Contains(result, "Command exited with status"))
+	})
+
+	t.Run("properly escapes arguments", func(t *testing.T) {
+		tool := tools.NewExec()
+
+		// Execute echo with arguments that need escaping
+		result, err := tool.Function(t.Context(), mustMarshalJSON(tools.ExecArgs{
+			Command: "echo",
+			Args:    []string{"Hello", "Special$Characters", "\"Quotes\"", "`Backticks`"},
+		}))
+
+		is.NotError(t, err)
+		is.True(t, strings.Contains(result, "Hello Special$Characters \"Quotes\" `Backticks`"))
+	})
+
+	t.Run("returns error for empty command", func(t *testing.T) {
+		tool := tools.NewExec()
+
+		// Execute with an empty command
+		_, err := tool.Function(t.Context(), mustMarshalJSON(tools.ExecArgs{
+			Command: "",
+		}))
+
+		is.True(t, err != nil)
+		is.Equal(t, "command cannot be empty", err.Error())
+	})
+
+	t.Run("handles command with multiple arguments", func(t *testing.T) {
+		tool := tools.NewExec()
+
+		// Execute a command with multiple arguments
+		result, err := tool.Function(t.Context(), mustMarshalJSON(tools.ExecArgs{
+			Command: "echo",
+			Args:    []string{"arg1", "arg2", "arg3"},
+		}))
+
+		is.NotError(t, err)
+		is.True(t, strings.Contains(result, "arg1 arg2 arg3"))
+	})
+
+	t.Run("handles binary data in stdin", func(t *testing.T) {
+		tool := tools.NewExec()
+
+		// Create binary data with null bytes
+		binaryInput := "Binary\x00Data\x00With\x00Nulls"
+
+		// Use hexdump to see the binary data
+		result, err := tool.Function(t.Context(), mustMarshalJSON(tools.ExecArgs{
+			Command: "hexdump",
+			Args:    []string{"-C"},
+			Input:   binaryInput,
+		}))
+
+		is.NotError(t, err)
+		// The hexdump output should contain "00" representing null bytes
+		is.True(t, strings.Contains(result, "00"))
+	})
+
+	t.Run("captures stderr output", func(t *testing.T) {
+		tool := tools.NewExec()
+
+		// Run a command that writes to stderr
+		result, err := tool.Function(t.Context(), mustMarshalJSON(tools.ExecArgs{
+			Command: "sh",
+			Args:    []string{"-c", "echo 'Standard output'; echo 'Error output' >&2"},
+		}))
+
+		is.NotError(t, err)
+		is.True(t, strings.Contains(result, "Standard output"))
+		is.True(t, strings.Contains(result, "Error output"))
+	})
+
+	t.Run("handles nonexistent command", func(t *testing.T) {
+		tool := tools.NewExec()
+
+		// Run a command that doesn't exist
+		result, err := tool.Function(t.Context(), mustMarshalJSON(tools.ExecArgs{
+			Command: "nonexistentcommand",
+		}))
+
+		is.True(t, err != nil)
+		is.True(t, strings.Contains(result, "ERROR:"))
+		is.True(t, strings.Contains(result, "executable file not found"))
+	})
+	
+	t.Run("respects custom timeout", func(t *testing.T) {
+		tool := tools.NewExec()
+
+		// Run a command with a short timeout that will exceed the timeout
+		start := time.Now()
+		result, err := tool.Function(t.Context(), mustMarshalJSON(tools.ExecArgs{
+			Command: "sleep",
+			Args:    []string{"5"},
+			Timeout: 1, // 1 second timeout
+		}))
+		elapsed := time.Since(start)
+
+		is.True(t, err != nil)
+		is.True(t, strings.Contains(result, "timed out"))
+		is.True(t, strings.Contains(err.Error(), "timed out"))
+		// Ensure it didn't wait the full 5 seconds
+		is.True(t, elapsed < 3*time.Second) 
+	})
+	
+	t.Run("handles command with no output", func(t *testing.T) {
+		tool := tools.NewExec()
+
+		// Execute a command that produces no output
+		result, err := tool.Function(t.Context(), mustMarshalJSON(tools.ExecArgs{
+			Command: "true",
+		}))
+
+		is.NotError(t, err)
+		is.True(t, strings.Contains(result, "Command executed successfully with no output"))
+	})
+
+}


### PR DESCRIPTION
Provides a controlled way for applications to execute system commands with proper timeout handling, input/output streaming, and error management. This enables integrations with external processes and system utilities while maintaining a consistent tool interface aligned with existing patterns.

🤖 Generated with [Claude Code](https://claude.ai/code)