### PR TITLE
Add HTML to Markdown conversion to Fetch tool

### DIFF
--- a/tools/fetch.go
+++ b/tools/fetch.go
@@ -111,6 +111,9 @@ func NewFetch(client *http.Client, completer gai.ChatCompleter) gai.Tool {
 			
 			// Set default output format to markdown if a converter is available, otherwise html
 			outputFormat := args.OutputFormat
+			if outputFormat != "" && outputFormat != outputFormatHTML && outputFormat != outputFormatMarkdown {
+				return "", fmt.Errorf("unsupported output format: %s. Supported formats are '%s' and '%s'", outputFormat, outputFormatHTML, outputFormatMarkdown)
+			}
 			if outputFormat == "" {
 				if converter != nil {
 					outputFormat = outputFormatMarkdown

--- a/tools/fetch.go
+++ b/tools/fetch.go
@@ -97,7 +97,7 @@ func NewFetch(client *http.Client, completer gai.ChatCompleter) gai.Tool {
 
 	return gai.Tool{
 		Name:        "fetch",
-		Description: "Fetch an HTML site and output the results as a string or markdown. Follows redirects automatically.",
+		Description: "Fetch an HTML site and output the results as a string or Markdown. Follows redirects automatically.",
 		Schema:      gai.GenerateSchema[FetchArgs](),
 		Function: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
 			var args FetchArgs


### PR DESCRIPTION
- Make Fetch tool accept a ChatCompleter parameter for HTML to Markdown conversion
- Add OutputFormat field to FetchArgs with html/markdown options
- Add automatic conversion of HTML responses to Markdown when requested
- Default to Markdown format when a converter is provided
- Return error if markdown is requested without a converter
- Update tests to verify both HTML and Markdown functionality

🤖 Generated with [Claude Code](https://claude.ai/code)