### PR TITLE
Add tool summarization feature across all tools

### DIFF
--- a/chat_complete.go
+++ b/chat_complete.go
@@ -172,6 +172,7 @@ type Tool struct {
 	Description string
 	Schema      ToolSchema
 	Function    ToolFunction
+	Summarize   ToolSummarize
 }
 
 // ToolSchema in JSON Schema format of the arguments the tool accepts.
@@ -194,6 +195,11 @@ func GenerateSchema[T any]() ToolSchema {
 }
 
 type ToolFunction func(ctx context.Context, rawArgs json.RawMessage) (string, error)
+
+// ToolSummarize is a function that, given the same args as Function, 
+// returns a human-readable summary of the tool call. This can be used to
+// display a prettier version of the tool call to the user.
+type ToolSummarize func(ctx context.Context, rawArgs json.RawMessage) (string, error)
 
 type ToolCall struct {
 	ID   string

--- a/chat_complete_test.go
+++ b/chat_complete_test.go
@@ -1,0 +1,73 @@
+package gai_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"maragu.dev/gai"
+	"maragu.dev/is"
+)
+
+type EchoArgs struct {
+	Text string `json:"text" jsonschema_description:"Text to echo."`
+}
+
+func TestToolSummarize(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a test tool with both Function and Summarize
+	tool := gai.Tool{
+		Name:        "echo",
+		Description: "Echo the input text",
+		Schema:      gai.GenerateSchema[EchoArgs](),
+		Function: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
+			var args EchoArgs
+			if err := json.Unmarshal(rawArgs, &args); err != nil {
+				return "", err
+			}
+			return args.Text, nil
+		},
+		Summarize: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
+			var args EchoArgs
+			if err := json.Unmarshal(rawArgs, &args); err != nil {
+				return "", err
+			}
+			return "Echo: " + args.Text, nil
+		},
+	}
+
+	// Test args
+	args := json.RawMessage(`{"text": "Hello, world!"}`)
+
+	// Test Function
+	result, err := tool.Function(ctx, args)
+	is.NotError(t, err)
+	is.Equal(t, "Hello, world!", result)
+
+	// Test Summarize
+	summary, err := tool.Summarize(ctx, args)
+	is.NotError(t, err)
+	is.Equal(t, "Echo: Hello, world!", summary)
+}
+
+// Test a tool without a Summarize function
+func TestToolWithoutSummarize(t *testing.T) {
+	tool := gai.Tool{
+		Name:        "echo",
+		Description: "Echo the input text",
+		Schema:      gai.GenerateSchema[EchoArgs](),
+		Function: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
+			var args EchoArgs
+			if err := json.Unmarshal(rawArgs, &args); err != nil {
+				return "", err
+			}
+			return args.Text, nil
+		},
+	}
+
+	// Ensure Summarize is nil
+	if tool.Summarize != nil {
+		t.Error("Expected Summarize to be nil")
+	}
+}

--- a/tools/exec.go
+++ b/tools/exec.go
@@ -33,6 +33,30 @@ Executes the provided command with the specified arguments and returns the outpu
 - Both stdout and stderr are captured and included in the output
 - Command arguments are properly escaped`,
 		Schema: gai.GenerateSchema[ExecArgs](),
+		Summarize: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
+			var args ExecArgs
+			if err := json.Unmarshal(rawArgs, &args); err != nil {
+				return "", fmt.Errorf("error unmarshaling exec args from JSON: %w", err)
+			}
+			
+			// Build command string with arguments
+			cmdString := args.Command
+			if len(args.Args) > 0 {
+				// Display at most 3 arguments in the summary
+				displayArgs := args.Args
+				if len(displayArgs) > 3 {
+					displayArgs = append(args.Args[:3], "...")
+				}
+				cmdString += " " + strings.Join(displayArgs, " ")
+			}
+			
+			// Add timeout info if non-default
+			if args.Timeout > 0 && args.Timeout != 30 {
+				return fmt.Sprintf("Executing command: %s (timeout: %ds)", cmdString, args.Timeout), nil
+			}
+			
+			return fmt.Sprintf("Executing command: %s", cmdString), nil
+		},
 		Function: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
 			var args ExecArgs
 			if err := json.Unmarshal(rawArgs, &args); err != nil {

--- a/tools/fetch.go
+++ b/tools/fetch.go
@@ -99,6 +99,23 @@ func NewFetch(client *http.Client, completer gai.ChatCompleter) gai.Tool {
 		Name:        "fetch",
 		Description: "Fetch an HTML site and output the results as a string or Markdown. Follows redirects automatically.",
 		Schema:      gai.GenerateSchema[FetchArgs](),
+		Summarize: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
+			var args FetchArgs
+			if err := json.Unmarshal(rawArgs, &args); err != nil {
+				return "", fmt.Errorf("error unmarshaling fetch args from JSON: %w", err)
+			}
+			
+			format := args.OutputFormat
+			if format == "" {
+				if converter != nil {
+					format = outputFormatMarkdown
+				} else {
+					format = outputFormatHTML
+				}
+			}
+			
+			return fmt.Sprintf("Fetching URL: %s (format: %s)", args.URL, format), nil
+		},
 		Function: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
 			var args FetchArgs
 			if err := json.Unmarshal(rawArgs, &args); err != nil {

--- a/tools/fetch_test.go
+++ b/tools/fetch_test.go
@@ -49,6 +49,14 @@ func TestNewFetch(t *testing.T) {
 
 		// Check tool name
 		is.Equal(t, "fetch", tool.Name)
+		
+		// Test the Summarize function
+		summary, err := tool.Summarize(t.Context(), mustMarshalJSON(tools.FetchArgs{
+			URL:          server.URL,
+			OutputFormat: "html",
+		}))
+		is.NotError(t, err)
+		is.Equal(t, "Fetching URL: "+server.URL+" (format: html)", summary)
 
 		// Execute the tool with the test server URL and HTML output format
 		result, err := tool.Function(t.Context(), mustMarshalJSON(tools.FetchArgs{
@@ -71,6 +79,14 @@ func TestNewFetch(t *testing.T) {
 		client := &http.Client{Timeout: 5 * time.Second}
 		completer := &mockChatCompleter{}
 		tool := tools.NewFetch(client, completer)
+		
+		// Test the Summarize function with markdown
+		summary, err := tool.Summarize(t.Context(), mustMarshalJSON(tools.FetchArgs{
+			URL:          server.URL,
+			OutputFormat: "markdown",
+		}))
+		is.NotError(t, err)
+		is.Equal(t, "Fetching URL: "+server.URL+" (format: markdown)", summary)
 
 		// Execute the tool with the test server URL and Markdown output format
 		result, err := tool.Function(t.Context(), mustMarshalJSON(tools.FetchArgs{

--- a/tools/memory.go
+++ b/tools/memory.go
@@ -21,6 +21,20 @@ func NewSaveMemory(ms memorySaver) gai.Tool {
 		Name:        "save_memory",
 		Description: "Save a memory, something you would like to remember for later conversations.",
 		Schema:      gai.GenerateSchema[SaveMemoryArgs](),
+		Summarize: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
+			var args SaveMemoryArgs
+			if err := json.Unmarshal(rawArgs, &args); err != nil {
+				return "", fmt.Errorf("error unmarshaling save_memory args from JSON: %w", err)
+			}
+			
+			// Truncate memory text if it's too long
+			memoryPreview := args.Memory
+			if len(memoryPreview) > 50 {
+				memoryPreview = memoryPreview[:46] + "..."
+			}
+			
+			return fmt.Sprintf("Saving memory: \"%s\"", memoryPreview), nil
+		},
 		Function: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
 			var args SaveMemoryArgs
 			if err := json.Unmarshal(rawArgs, &args); err != nil {
@@ -47,6 +61,9 @@ func NewGetMemories(mg memoryGetter) gai.Tool {
 		Name:        "get_memories",
 		Description: "Get all saved memories.",
 		Schema:      gai.GenerateSchema[GetMemoryArgs](),
+		Summarize: func(ctx context.Context, _ json.RawMessage) (string, error) {
+			return "Getting all saved memories", nil
+		},
 		Function: func(ctx context.Context, _ json.RawMessage) (string, error) {
 			memories, err := mg.GetMemories(ctx)
 			if err != nil {
@@ -71,6 +88,14 @@ func NewSearchMemories(ms memorySearcher) gai.Tool {
 		Name:        "search_memories",
 		Description: "Search saved memories using a query string.",
 		Schema:      gai.GenerateSchema[SearchMemoriesArgs](),
+		Summarize: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
+			var args SearchMemoriesArgs
+			if err := json.Unmarshal(rawArgs, &args); err != nil {
+				return "", fmt.Errorf("error unmarshaling search_memories args from JSON: %w", err)
+			}
+			
+			return fmt.Sprintf("Searching memories for: \"%s\"", args.Query), nil
+		},
 		Function: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
 			var args SearchMemoriesArgs
 			if err := json.Unmarshal(rawArgs, &args); err != nil {

--- a/tools/memory_test.go
+++ b/tools/memory_test.go
@@ -53,6 +53,13 @@ func TestNewSaveMemory(t *testing.T) {
 		tool := tools.NewSaveMemory(store)
 
 		is.Equal(t, "save_memory", tool.Name)
+		
+		// Test the Summarize function
+		summary, err := tool.Summarize(t.Context(), mustMarshalJSON(tools.SaveMemoryArgs{
+			Memory: "Remember to buy milk",
+		}))
+		is.NotError(t, err)
+		is.Equal(t, "Saving memory: \"Remember to buy milk\"", summary)
 
 		memory := "Remember to buy milk"
 		result, err := tool.Function(t.Context(), mustMarshalJSON(tools.SaveMemoryArgs{
@@ -86,6 +93,19 @@ func TestNewSaveMemory(t *testing.T) {
 		is.True(t, err != nil)
 		is.True(t, strings.Contains(err.Error(), "error unmarshaling"))
 	})
+	
+	t.Run("truncates long memory text in summary", func(t *testing.T) {
+		store := &mockMemoryStore{}
+		tool := tools.NewSaveMemory(store)
+		
+		longMemory := "This is a very long memory that should be truncated in the summary because it exceeds the character limit for displaying in summaries"
+		
+		summary, err := tool.Summarize(t.Context(), mustMarshalJSON(tools.SaveMemoryArgs{
+			Memory: longMemory,
+		}))
+		is.NotError(t, err)
+		is.Equal(t, "Saving memory: \"This is a very long memory that should be trun...\"", summary)
+	})
 }
 
 func TestNewGetMemories(t *testing.T) {
@@ -96,6 +116,11 @@ func TestNewGetMemories(t *testing.T) {
 		tool := tools.NewGetMemories(store)
 
 		is.Equal(t, "get_memories", tool.Name)
+		
+		// Test the Summarize function
+		summary, err := tool.Summarize(t.Context(), mustMarshalJSON(tools.GetMemoryArgs{}))
+		is.NotError(t, err)
+		is.Equal(t, "Getting all saved memories", summary)
 
 		result, err := tool.Function(t.Context(), mustMarshalJSON(tools.GetMemoryArgs{}))
 		
@@ -136,6 +161,13 @@ func TestNewSearchMemories(t *testing.T) {
 		tool := tools.NewSearchMemories(store)
 
 		is.Equal(t, "search_memories", tool.Name)
+		
+		// Test the Summarize function
+		summary, err := tool.Summarize(t.Context(), mustMarshalJSON(tools.SearchMemoriesArgs{
+			Query: "pet",
+		}))
+		is.NotError(t, err)
+		is.Equal(t, "Searching memories for: \"pet\"", summary)
 
 		result, err := tool.Function(t.Context(), mustMarshalJSON(tools.SearchMemoriesArgs{
 			Query: "pet",
@@ -203,4 +235,3 @@ func TestNewSearchMemories(t *testing.T) {
 		is.True(t, strings.Contains(err.Error(), "error unmarshaling"))
 	})
 }
-

--- a/tools/time.go
+++ b/tools/time.go
@@ -25,5 +25,8 @@ func NewGetTime(now func() time.Time) gai.Tool {
 
 			return now().Format(time.RFC3339), nil
 		},
+		Summarize: func(ctx context.Context, args json.RawMessage) (string, error) {
+			return "Getting current time", nil
+		},
 	}
 }

--- a/tools/time_test.go
+++ b/tools/time_test.go
@@ -24,4 +24,13 @@ func TestNewGetTime(t *testing.T) {
 		is.NotError(t, err)
 		is.Equal(t, "2023-05-01T12:30:45Z", result)
 	})
+
+	t.Run("summarize function returns a human-readable description", func(t *testing.T) {
+		// Create tool with a function that returns our fixed time
+		tool := tools.NewGetTime(time.Now)
+
+		summary, err := tool.Summarize(t.Context(), mustMarshalJSON(tools.GetTimeArgs{}))
+		is.NotError(t, err)
+		is.Equal(t, "Getting current time", summary)
+	})
 }


### PR DESCRIPTION
This commit implements the tool summarization feature by:
- Adding Summarize field and type to the Tool struct in chat_complete.go
- Adding tests for the Summarize functionality in chat_complete_test.go
- Implementing Summarize functions for all tools:
  - ReadFile and ListDir tools in file.go
  - Exec tool in exec.go
  - Fetch tool in fetch.go
  - Memory tools (SaveMemory, GetMemories, SearchMemories) in memory.go
  - GetTime tool in time.go

The Summarize functions provide human-readable descriptions of tool operations that can be displayed to users when tools are invoked, improving UX.

🤖 Generated with [Claude Code](https://claude.ai/code)