### PR TITLE
Add Summarize field to gai.Tool for concise tool call summaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ cover:
 
 .PHONY: evaluate
 evaluate:
-	go test -run TestEval ./....PHONY: fmt
+	go test -run TestEval ./...
 
 .PHONY: fmt
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,18 @@
 .PHONY: benchmark
 benchmark:
-	go test -bench=. ./...
+	go test -bench . ./...
 
 .PHONY: cover
 cover:
-	go tool cover -html=cover.out
+	go tool cover -html cover.out
 
 .PHONY: evaluate
 evaluate:
-	go test -run TestEval ./...
+	go test -run TestEval ./....PHONY: fmt
+
+.PHONY: fmt
+fmt:
+	goimports -w -local `head -n 1 go.mod | sed 's/^module //'` .
 
 .PHONY: lint
 lint:
@@ -16,12 +20,4 @@ lint:
 
 .PHONY: test
 test:
-	go test -coverprofile=cover.out -shuffle on ./...
-
-.PHONY: test-down
-test-down:
-	docker compose down
-
-.PHONY: test-up
-test-up:
-	docker compose up -d
+	go test -coverprofile cover.out -shuffle on ./...

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,11 @@ lint:
 .PHONY: test
 test:
 	go test -coverprofile cover.out -shuffle on ./...
+
+.PHONY: test-down
+test-down:
+	docker compose down
+
+.PHONY: test-up
+test-up:
+	docker compose up -d

--- a/chat_complete.go
+++ b/chat_complete.go
@@ -172,6 +172,7 @@ type Tool struct {
 	Description string
 	Schema      ToolSchema
 	Function    ToolFunction
+	Summarize   ToolFunction
 }
 
 // ToolSchema in JSON Schema format of the arguments the tool accepts.

--- a/docs/plans/tool-summarize-implementation-plan.md
+++ b/docs/plans/tool-summarize-implementation-plan.md
@@ -1,0 +1,105 @@
+# Tool Summarize Function Implementation Plan
+
+## Overview
+The Summarize field for `gai.Tool` should provide a concise summary of a tool call based on the supplied arguments. It should only summarize the arguments themselves - the tool name should not be duplicated in the summary.
+
+## General Guidelines
+- Keep summaries concise and readable
+- Truncate long values appropriately (e.g., use ellipsis "..." for text over ~30 chars)
+- Focus on the most important arguments
+- Omit optional arguments if they use default values
+- For tools with no arguments, return a simple descriptive phrase
+
+## Tool-Specific Implementation Plans
+
+### 1. exec.go - Command Execution Tool
+**Summary Format:**
+- With args: `command="<cmd>" args=[<arg1>,<arg2>,...]`
+- Without args: `command="<cmd>"`
+- With long args list: `command="<cmd>" args=[<arg1>,<arg2>,...] (X total)`
+- With input: `command="<cmd>" input="<truncated...>"`
+- With timeout: `command="<cmd>" timeout=<seconds>s`
+
+**Implementation Notes:**
+- Always show the command
+- Show args if present (truncate list if >3 items)
+- Show input if present (truncate to ~20 chars)
+- Show timeout only if different from default (30s)
+
+### 2. fetch.go - URL Fetching Tool
+**Summary Format:**
+- Basic: `url="<URL>"`
+- With format: `url="<URL>" format="<format>"`
+
+**Implementation Notes:**
+- Always show the URL
+- Only show output_format if explicitly specified
+- URL should be shown in full unless extremely long (>100 chars)
+
+### 3. file.go - File Operations Tools
+
+#### read_file
+**Summary Format:** `path="<filepath>"`
+
+#### list_dir
+**Summary Format:**
+- With path: `path="<dirpath>"`
+- Without path: `current directory`
+
+#### edit_file
+**Summary Format:** `path="<filepath>" search="<truncated...>" replace="<truncated...>"`
+
+**Implementation Notes:**
+- Truncate search_str and replace_str to ~20 chars each
+- Show ellipsis if truncated
+
+### 4. memory.go - Memory Management Tools
+
+#### save_memory
+**Summary Format:** `memory="<truncated...>"`
+
+**Implementation Notes:**
+- Truncate memory content to ~30 chars
+- Show ellipsis if truncated
+
+#### get_memories
+**Summary Format:** `all memories`
+
+#### search_memories
+**Summary Format:** `query="<query>"`
+
+### 5. time.go - Time Tool
+
+#### get_time
+**Summary Format:** `current time`
+
+## Implementation Strategy
+
+1. Add a Summarize field to each tool during creation
+2. The Summarize function should:
+   - Take the JSON RawMessage arguments as input
+   - Unmarshal to the appropriate args struct
+   - Build a summary string based on the format above
+   - Return the summary string
+
+## Example Implementation Pattern
+
+```go
+Summarize: func(rawArgs json.RawMessage) string {
+    var args ArgsStruct
+    if err := json.Unmarshal(rawArgs, &args); err != nil {
+        return "error parsing arguments"
+    }
+    
+    // Build summary based on args
+    // ...
+    
+    return summary
+}
+```
+
+## Utility Functions
+Consider creating helper functions for:
+- Truncating strings with ellipsis
+- Formatting arrays/lists with counts
+- Building key-value pair strings

--- a/tools/file.go
+++ b/tools/file.go
@@ -25,6 +25,13 @@ func NewReadFile(root *os.Root) gai.Tool {
 		Name:        "read_file",
 		Description: "Read the contents of a given relative file path. Use this when you want to see what's inside a file. Do not use this with directory names.",
 		Schema:      gai.GenerateSchema[ReadFileArgs](),
+		Summarize: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
+			var args ReadFileArgs
+			if err := json.Unmarshal(rawArgs, &args); err != nil {
+				return "error parsing arguments", nil
+			}
+			return fmt.Sprintf(`path="%s"`, args.Path), nil
+		},
 		Function: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
 			var args ReadFileArgs
 			if err := json.Unmarshal(rawArgs, &args); err != nil {
@@ -50,6 +57,16 @@ func NewListDir(root *os.Root) gai.Tool {
 		Name:        "list_dir",
 		Description: "List files and directories at a given path recursively. If no path is provided, lists files and directories in the current directory.",
 		Schema:      gai.GenerateSchema[ListDirArgs](),
+		Summarize: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
+			var args ListDirArgs
+			if err := json.Unmarshal(rawArgs, &args); err != nil {
+				return "error parsing arguments", nil
+			}
+			if args.Path == "" || args.Path == "." {
+				return "", nil
+			}
+			return fmt.Sprintf(`path="%s"`, args.Path), nil
+		},
 		Function: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
 			var args ListDirArgs
 			if err := json.Unmarshal(rawArgs, &args); err != nil {
@@ -113,6 +130,24 @@ Replaces 'search_str' with 'replace_str' in the given file. 'search_str' and 're
 If the file specified with 'path' doesn't exist, it will be created.
 `,
 		Schema: gai.GenerateSchema[EditFileArgs](),
+		Summarize: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
+			var args EditFileArgs
+			if err := json.Unmarshal(rawArgs, &args); err != nil {
+				return "error parsing arguments", nil
+			}
+
+			// Truncate search and replace strings
+			searchStr := args.SearchStr
+			if len(searchStr) > 20 {
+				searchStr = searchStr[:20] + "..."
+			}
+			replaceStr := args.ReplaceStr
+			if len(replaceStr) > 20 {
+				replaceStr = replaceStr[:20] + "..."
+			}
+
+			return fmt.Sprintf(`path="%s" search="%s" replace="%s"`, args.Path, searchStr, replaceStr), nil
+		},
 		Function: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
 			var args EditFileArgs
 			if err := json.Unmarshal(rawArgs, &args); err != nil {

--- a/tools/memory.go
+++ b/tools/memory.go
@@ -21,6 +21,20 @@ func NewSaveMemory(ms memorySaver) gai.Tool {
 		Name:        "save_memory",
 		Description: "Save a memory, something you would like to remember for later conversations.",
 		Schema:      gai.GenerateSchema[SaveMemoryArgs](),
+		Summarize: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
+			var args SaveMemoryArgs
+			if err := json.Unmarshal(rawArgs, &args); err != nil {
+				return "error parsing arguments", nil
+			}
+
+			// Truncate memory content
+			memory := args.Memory
+			if len(memory) > 30 {
+				memory = memory[:30] + "..."
+			}
+
+			return fmt.Sprintf(`memory="%s"`, memory), nil
+		},
 		Function: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
 			var args SaveMemoryArgs
 			if err := json.Unmarshal(rawArgs, &args); err != nil {
@@ -47,6 +61,9 @@ func NewGetMemories(mg memoryGetter) gai.Tool {
 		Name:        "get_memories",
 		Description: "Get all saved memories.",
 		Schema:      gai.GenerateSchema[GetMemoryArgs](),
+		Summarize: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
+			return "", nil
+		},
 		Function: func(ctx context.Context, _ json.RawMessage) (string, error) {
 			memories, err := mg.GetMemories(ctx)
 			if err != nil {
@@ -71,6 +88,13 @@ func NewSearchMemories(ms memorySearcher) gai.Tool {
 		Name:        "search_memories",
 		Description: "Search saved memories using a query string.",
 		Schema:      gai.GenerateSchema[SearchMemoriesArgs](),
+		Summarize: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
+			var args SearchMemoriesArgs
+			if err := json.Unmarshal(rawArgs, &args); err != nil {
+				return "error parsing arguments", nil
+			}
+			return fmt.Sprintf(`query="%s"`, args.Query), nil
+		},
 		Function: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
 			var args SearchMemoriesArgs
 			if err := json.Unmarshal(rawArgs, &args); err != nil {

--- a/tools/memory_test.go
+++ b/tools/memory_test.go
@@ -122,37 +122,6 @@ func TestNewSaveMemory(t *testing.T) {
 		is.Equal(t, "error parsing arguments", summary)
 	})
 
-	t.Run("summarize get_memories", func(t *testing.T) {
-		store := &mockMemoryStore{}
-		tool := tools.NewGetMemories(store)
-
-		summary, err := tool.Summarize(t.Context(), mustMarshalJSON(tools.GetMemoryArgs{}))
-
-		is.NotError(t, err)
-		is.Equal(t, "", summary)
-	})
-
-	t.Run("summarize search_memories", func(t *testing.T) {
-		store := &mockMemoryStore{}
-		tool := tools.NewSearchMemories(store)
-
-		summary, err := tool.Summarize(t.Context(), mustMarshalJSON(tools.SearchMemoriesArgs{
-			Query: "coffee",
-		}))
-
-		is.NotError(t, err)
-		is.Equal(t, `query="coffee"`, summary)
-	})
-
-	t.Run("summarize search_memories with invalid JSON", func(t *testing.T) {
-		store := &mockMemoryStore{}
-		tool := tools.NewSearchMemories(store)
-
-		summary, err := tool.Summarize(t.Context(), []byte(`{invalid json`))
-
-		is.NotError(t, err)
-		is.Equal(t, "error parsing arguments", summary)
-	})
 }
 
 func TestNewGetMemories(t *testing.T) {
@@ -188,6 +157,16 @@ func TestNewGetMemories(t *testing.T) {
 
 		is.True(t, err != nil)
 		is.True(t, strings.Contains(err.Error(), "error getting memories"))
+	})
+
+	t.Run("summarize get_memories", func(t *testing.T) {
+		store := &mockMemoryStore{}
+		tool := tools.NewGetMemories(store)
+
+		summary, err := tool.Summarize(t.Context(), mustMarshalJSON(tools.GetMemoryArgs{}))
+
+		is.NotError(t, err)
+		is.Equal(t, "", summary)
 	})
 }
 
@@ -268,50 +247,6 @@ func TestNewSearchMemories(t *testing.T) {
 
 		is.True(t, err != nil)
 		is.True(t, strings.Contains(err.Error(), "error unmarshaling"))
-	})
-
-	t.Run("summarize save_memory with short memory", func(t *testing.T) {
-		store := &mockMemoryStore{}
-		tool := tools.NewSaveMemory(store)
-
-		summary, err := tool.Summarize(t.Context(), mustMarshalJSON(tools.SaveMemoryArgs{
-			Memory: "Buy milk",
-		}))
-
-		is.NotError(t, err)
-		is.Equal(t, `memory="Buy milk"`, summary)
-	})
-
-	t.Run("summarize save_memory with long memory", func(t *testing.T) {
-		store := &mockMemoryStore{}
-		tool := tools.NewSaveMemory(store)
-
-		summary, err := tool.Summarize(t.Context(), mustMarshalJSON(tools.SaveMemoryArgs{
-			Memory: "This is a very long memory that should be truncated after 30 characters",
-		}))
-
-		is.NotError(t, err)
-		is.Equal(t, `memory="This is a very long memory tha..."`, summary)
-	})
-
-	t.Run("summarize save_memory with invalid JSON", func(t *testing.T) {
-		store := &mockMemoryStore{}
-		tool := tools.NewSaveMemory(store)
-
-		summary, err := tool.Summarize(t.Context(), []byte(`{invalid json`))
-
-		is.NotError(t, err)
-		is.Equal(t, "error parsing arguments", summary)
-	})
-
-	t.Run("summarize get_memories", func(t *testing.T) {
-		store := &mockMemoryStore{}
-		tool := tools.NewGetMemories(store)
-
-		summary, err := tool.Summarize(t.Context(), mustMarshalJSON(tools.GetMemoryArgs{}))
-
-		is.NotError(t, err)
-		is.Equal(t, "", summary)
 	})
 
 	t.Run("summarize search_memories", func(t *testing.T) {

--- a/tools/memory_test.go
+++ b/tools/memory_test.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"maragu.dev/gai/tools"
 	"maragu.dev/is"
+
+	"maragu.dev/gai/tools"
 )
 
 // mockMemoryStore implements all the memory-related interfaces
@@ -36,7 +37,7 @@ func (m *mockMemoryStore) SearchMemories(_ context.Context, query string) ([]str
 	if m.failMode {
 		return nil, errors.New("mock memory store fail")
 	}
-	
+
 	var results []string
 	queryLower := strings.ToLower(query)
 	for _, memory := range m.memories {
@@ -58,7 +59,7 @@ func TestNewSaveMemory(t *testing.T) {
 		result, err := tool.Function(t.Context(), mustMarshalJSON(tools.SaveMemoryArgs{
 			Memory: memory,
 		}))
-		
+
 		is.NotError(t, err)
 		is.Equal(t, "OK", result)
 		is.Equal(t, 1, len(store.memories))
@@ -72,7 +73,7 @@ func TestNewSaveMemory(t *testing.T) {
 		_, err := tool.Function(t.Context(), mustMarshalJSON(tools.SaveMemoryArgs{
 			Memory: "This will fail",
 		}))
-		
+
 		is.True(t, err != nil)
 		is.True(t, strings.Contains(err.Error(), "error saving memory"))
 	})
@@ -82,9 +83,75 @@ func TestNewSaveMemory(t *testing.T) {
 		tool := tools.NewSaveMemory(store)
 
 		_, err := tool.Function(t.Context(), json.RawMessage(`{invalid json`))
-		
+
 		is.True(t, err != nil)
 		is.True(t, strings.Contains(err.Error(), "error unmarshaling"))
+	})
+
+	t.Run("summarize save_memory with short memory", func(t *testing.T) {
+		store := &mockMemoryStore{}
+		tool := tools.NewSaveMemory(store)
+
+		summary, err := tool.Summarize(t.Context(), mustMarshalJSON(tools.SaveMemoryArgs{
+			Memory: "Buy milk",
+		}))
+
+		is.NotError(t, err)
+		is.Equal(t, `memory="Buy milk"`, summary)
+	})
+
+	t.Run("summarize save_memory with long memory", func(t *testing.T) {
+		store := &mockMemoryStore{}
+		tool := tools.NewSaveMemory(store)
+
+		summary, err := tool.Summarize(t.Context(), mustMarshalJSON(tools.SaveMemoryArgs{
+			Memory: "This is a very long memory that should be truncated after 30 characters",
+		}))
+
+		is.NotError(t, err)
+		is.Equal(t, `memory="This is a very long memory tha..."`, summary)
+	})
+
+	t.Run("summarize save_memory with invalid JSON", func(t *testing.T) {
+		store := &mockMemoryStore{}
+		tool := tools.NewSaveMemory(store)
+
+		summary, err := tool.Summarize(t.Context(), []byte(`{invalid json`))
+
+		is.NotError(t, err)
+		is.Equal(t, "error parsing arguments", summary)
+	})
+
+	t.Run("summarize get_memories", func(t *testing.T) {
+		store := &mockMemoryStore{}
+		tool := tools.NewGetMemories(store)
+
+		summary, err := tool.Summarize(t.Context(), mustMarshalJSON(tools.GetMemoryArgs{}))
+
+		is.NotError(t, err)
+		is.Equal(t, "", summary)
+	})
+
+	t.Run("summarize search_memories", func(t *testing.T) {
+		store := &mockMemoryStore{}
+		tool := tools.NewSearchMemories(store)
+
+		summary, err := tool.Summarize(t.Context(), mustMarshalJSON(tools.SearchMemoriesArgs{
+			Query: "coffee",
+		}))
+
+		is.NotError(t, err)
+		is.Equal(t, `query="coffee"`, summary)
+	})
+
+	t.Run("summarize search_memories with invalid JSON", func(t *testing.T) {
+		store := &mockMemoryStore{}
+		tool := tools.NewSearchMemories(store)
+
+		summary, err := tool.Summarize(t.Context(), []byte(`{invalid json`))
+
+		is.NotError(t, err)
+		is.Equal(t, "error parsing arguments", summary)
 	})
 }
 
@@ -98,7 +165,7 @@ func TestNewGetMemories(t *testing.T) {
 		is.Equal(t, "get_memories", tool.Name)
 
 		result, err := tool.Function(t.Context(), mustMarshalJSON(tools.GetMemoryArgs{}))
-		
+
 		is.NotError(t, err)
 		is.Equal(t, "Memories: [Memory 1 Memory 2 Memory 3]", result)
 	})
@@ -108,7 +175,7 @@ func TestNewGetMemories(t *testing.T) {
 		tool := tools.NewGetMemories(store)
 
 		result, err := tool.Function(t.Context(), mustMarshalJSON(tools.GetMemoryArgs{}))
-		
+
 		is.NotError(t, err)
 		is.Equal(t, "Memories: []", result)
 	})
@@ -118,7 +185,7 @@ func TestNewGetMemories(t *testing.T) {
 		tool := tools.NewGetMemories(store)
 
 		_, err := tool.Function(t.Context(), mustMarshalJSON(tools.GetMemoryArgs{}))
-		
+
 		is.True(t, err != nil)
 		is.True(t, strings.Contains(err.Error(), "error getting memories"))
 	})
@@ -140,7 +207,7 @@ func TestNewSearchMemories(t *testing.T) {
 		result, err := tool.Function(t.Context(), mustMarshalJSON(tools.SearchMemoriesArgs{
 			Query: "pet",
 		}))
-		
+
 		is.NotError(t, err)
 		is.Equal(t, "Found memories: [My pet rock needs a bath but hates getting wet Aliens probably think humans are weird for keeping plants as pets]", result)
 	})
@@ -158,7 +225,7 @@ func TestNewSearchMemories(t *testing.T) {
 		result, err := tool.Function(t.Context(), mustMarshalJSON(tools.SearchMemoriesArgs{
 			Query: "my",
 		}))
-		
+
 		is.NotError(t, err)
 		is.Equal(t, "Found memories: [I dreamt my code compiled on the first try My rubber duck debugger judged me today]", result)
 	})
@@ -176,7 +243,7 @@ func TestNewSearchMemories(t *testing.T) {
 		result, err := tool.Function(t.Context(), mustMarshalJSON(tools.SearchMemoriesArgs{
 			Query: "coffee",
 		}))
-		
+
 		is.NotError(t, err)
 		is.Equal(t, "No memories found matching the query.", result)
 	})
@@ -188,7 +255,7 @@ func TestNewSearchMemories(t *testing.T) {
 		_, err := tool.Function(t.Context(), mustMarshalJSON(tools.SearchMemoriesArgs{
 			Query: "anything",
 		}))
-		
+
 		is.True(t, err != nil)
 		is.True(t, strings.Contains(err.Error(), "error searching memories"))
 	})
@@ -198,9 +265,74 @@ func TestNewSearchMemories(t *testing.T) {
 		tool := tools.NewSearchMemories(store)
 
 		_, err := tool.Function(t.Context(), json.RawMessage(`{invalid json`))
-		
+
 		is.True(t, err != nil)
 		is.True(t, strings.Contains(err.Error(), "error unmarshaling"))
 	})
-}
 
+	t.Run("summarize save_memory with short memory", func(t *testing.T) {
+		store := &mockMemoryStore{}
+		tool := tools.NewSaveMemory(store)
+
+		summary, err := tool.Summarize(t.Context(), mustMarshalJSON(tools.SaveMemoryArgs{
+			Memory: "Buy milk",
+		}))
+
+		is.NotError(t, err)
+		is.Equal(t, `memory="Buy milk"`, summary)
+	})
+
+	t.Run("summarize save_memory with long memory", func(t *testing.T) {
+		store := &mockMemoryStore{}
+		tool := tools.NewSaveMemory(store)
+
+		summary, err := tool.Summarize(t.Context(), mustMarshalJSON(tools.SaveMemoryArgs{
+			Memory: "This is a very long memory that should be truncated after 30 characters",
+		}))
+
+		is.NotError(t, err)
+		is.Equal(t, `memory="This is a very long memory tha..."`, summary)
+	})
+
+	t.Run("summarize save_memory with invalid JSON", func(t *testing.T) {
+		store := &mockMemoryStore{}
+		tool := tools.NewSaveMemory(store)
+
+		summary, err := tool.Summarize(t.Context(), []byte(`{invalid json`))
+
+		is.NotError(t, err)
+		is.Equal(t, "error parsing arguments", summary)
+	})
+
+	t.Run("summarize get_memories", func(t *testing.T) {
+		store := &mockMemoryStore{}
+		tool := tools.NewGetMemories(store)
+
+		summary, err := tool.Summarize(t.Context(), mustMarshalJSON(tools.GetMemoryArgs{}))
+
+		is.NotError(t, err)
+		is.Equal(t, "", summary)
+	})
+
+	t.Run("summarize search_memories", func(t *testing.T) {
+		store := &mockMemoryStore{}
+		tool := tools.NewSearchMemories(store)
+
+		summary, err := tool.Summarize(t.Context(), mustMarshalJSON(tools.SearchMemoriesArgs{
+			Query: "coffee",
+		}))
+
+		is.NotError(t, err)
+		is.Equal(t, `query="coffee"`, summary)
+	})
+
+	t.Run("summarize search_memories with invalid JSON", func(t *testing.T) {
+		store := &mockMemoryStore{}
+		tool := tools.NewSearchMemories(store)
+
+		summary, err := tool.Summarize(t.Context(), []byte(`{invalid json`))
+
+		is.NotError(t, err)
+		is.Equal(t, "error parsing arguments", summary)
+	})
+}

--- a/tools/time.go
+++ b/tools/time.go
@@ -17,6 +17,9 @@ func NewGetTime(now func() time.Time) gai.Tool {
 		Name:        "get_time",
 		Description: "Get the current date and time, in the format YYYY-MM-DDTHH:MM:SSZ (RFC3339).",
 		Schema:      gai.GenerateSchema[GetTimeArgs](),
+		Summarize: func(ctx context.Context, rawArgs json.RawMessage) (string, error) {
+			return "", nil
+		},
 		Function: func(ctx context.Context, args json.RawMessage) (string, error) {
 			var getTimeArgs GetTimeArgs
 			if err := json.Unmarshal(args, &getTimeArgs); err != nil {

--- a/tools/time_test.go
+++ b/tools/time_test.go
@@ -4,15 +4,16 @@ import (
 	"testing"
 	"time"
 
-	"maragu.dev/gai/tools"
 	"maragu.dev/is"
+
+	"maragu.dev/gai/tools"
 )
 
 func TestNewGetTime(t *testing.T) {
 	t.Run("returns the current time in RFC3339 format", func(t *testing.T) {
 		// Create a fixed time for testing
 		fixedTime := time.Date(2023, 5, 1, 12, 30, 45, 0, time.UTC)
-		
+
 		// Create tool with a function that returns our fixed time
 		tool := tools.NewGetTime(func() time.Time {
 			return fixedTime
@@ -23,5 +24,23 @@ func TestNewGetTime(t *testing.T) {
 		result, err := tool.Function(t.Context(), mustMarshalJSON(tools.GetTimeArgs{}))
 		is.NotError(t, err)
 		is.Equal(t, "2023-05-01T12:30:45Z", result)
+	})
+
+	t.Run("summarize get_time", func(t *testing.T) {
+		// Create tool with any time function (not used in summarize)
+		tool := tools.NewGetTime(time.Now)
+
+		summary, err := tool.Summarize(t.Context(), mustMarshalJSON(tools.GetTimeArgs{}))
+		is.NotError(t, err)
+		is.Equal(t, "", summary)
+	})
+
+	t.Run("summarize get_time with invalid JSON", func(t *testing.T) {
+		// Create tool with any time function (not used in summarize)
+		tool := tools.NewGetTime(time.Now)
+
+		summary, err := tool.Summarize(t.Context(), []byte(`{invalid json`))
+		is.NotError(t, err)
+		is.Equal(t, "", summary)
 	})
 }


### PR DESCRIPTION
This change adds a new Summarize field to the Tool struct that provides concise summaries of tool calls based on their arguments. The summaries focus on the most important parameters while omitting defaults and truncating long values appropriately.

Key changes:
- Add Summarize field to gai.Tool struct with same signature as Function
- Implement Summarize for all tools in the tools package:
  - exec: Shows command, args, input, and non-default timeout
  - fetch: Shows URL and output format if specified
  - file: Shows paths and truncated search/replace strings
  - memory: Shows truncated memory content or query
  - time: Returns empty string (no arguments)
- Add comprehensive tests for all Summarize implementations
- Create implementation plan documentation

The Summarize function returns an empty string for tools with no arguments or default values, and "error parsing arguments" when JSON parsing fails.