### PR TITLE
Roll back some of the `gai.Schema` fields

### DIFF
--- a/chat_complete.go
+++ b/chat_complete.go
@@ -210,51 +210,54 @@ type Schema struct {
 	// Optional. The value should be validated against any (one or more) of the subschemas
 	// in the list.
 	AnyOf []*Schema `json:"anyOf,omitempty"`
+
 	// Optional. Default value of the data.
 	Default any `json:"default,omitempty"`
+
 	// Optional. The description of the data.
 	Description string `json:"description,omitempty"`
+
 	// Optional. Possible values of the element of primitive type with enum format. Examples:
 	// 1. We can define direction as : {type:STRING, format:enum, enum:["EAST", NORTH",
 	// "SOUTH", "WEST"]} 2. We can define apartment number as : {type:INTEGER, format:enum,
 	// enum:["101", "201", "301"]}
 	Enum []string `json:"enum,omitempty"`
+
 	// Optional. Example of the object. Will only populated when the object is the root.
 	Example any `json:"example,omitempty"`
+
 	// Optional. The format of the data. Supported formats: for NUMBER type: "float", "double"
 	// for INTEGER type: "int32", "int64" for STRING type: "email", "byte", etc
 	Format string `json:"format,omitempty"`
+
 	// Optional. SCHEMA FIELDS FOR TYPE ARRAY Schema of the elements of Type.ARRAY.
 	Items *Schema `json:"items,omitempty"`
+
 	// Optional. Maximum number of the elements for Type.ARRAY.
 	MaxItems *int64 `json:"maxItems,omitempty,string"`
-	// Optional. Maximum length of the Type.STRING
-	MaxLength *int64 `json:"maxLength,omitempty,string"`
-	// Optional. Maximum number of the properties for Type.OBJECT.
-	MaxProperties *int64 `json:"maxProperties,omitempty,string"`
+
 	// Optional. Maximum value of the Type.INTEGER and Type.NUMBER
 	Maximum *float64 `json:"maximum,omitempty"`
+
 	// Optional. Minimum number of the elements for Type.ARRAY.
 	MinItems *int64 `json:"minItems,omitempty,string"`
-	// Optional. SCHEMA FIELDS FOR TYPE STRING Minimum length of the Type.STRING
-	MinLength *int64 `json:"minLength,omitempty,string"`
-	// Optional. Minimum number of the properties for Type.OBJECT.
-	MinProperties *int64 `json:"minProperties,omitempty,string"`
+
 	// Optional. Minimum value of the Type.INTEGER and Type.NUMBER.
 	Minimum *float64 `json:"minimum,omitempty"`
-	// Optional. Indicates if the value may be null.
-	Nullable *bool `json:"nullable,omitempty"`
-	// Optional. Pattern of the Type.STRING to restrict a string to a regular expression.
-	Pattern string `json:"pattern,omitempty"`
+
 	// Optional. SCHEMA FIELDS FOR TYPE OBJECT Properties of Type.OBJECT.
 	Properties map[string]*Schema `json:"properties,omitempty"`
+
 	// Optional. The order of the properties. Not a standard field in open API spec. Only
 	// used to support the order of the properties.
 	PropertyOrdering []string `json:"propertyOrdering,omitempty"`
+
 	// Optional. Required properties of Type.OBJECT.
 	Required []string `json:"required,omitempty"`
+
 	// Optional. The title of the Schema.
 	Title string `json:"title,omitempty"`
+
 	// Optional. The type of the data.
 	Type SchemaType `json:"type,omitempty"`
 }
@@ -280,7 +283,6 @@ func convertJSONSchemaToSchema(js *jsonschema.Schema) Schema {
 		Title:       js.Title,
 		Default:     js.Default,
 		Format:      js.Format,
-		Pattern:     js.Pattern,
 	}
 
 	// Convert example (Examples is a slice, use first one if available)
@@ -326,16 +328,6 @@ func convertJSONSchemaToSchema(js *jsonschema.Schema) Schema {
 		}
 	}
 
-	// Convert string constraints
-	if js.MinLength != nil {
-		minLen := int64(*js.MinLength)
-		s.MinLength = &minLen
-	}
-	if js.MaxLength != nil {
-		maxLen := int64(*js.MaxLength)
-		s.MaxLength = &maxLen
-	}
-
 	// Convert array constraints
 	if js.MinItems != nil {
 		minItems := int64(*js.MinItems)
@@ -351,14 +343,6 @@ func convertJSONSchemaToSchema(js *jsonschema.Schema) Schema {
 	}
 
 	// Convert object constraints
-	if js.MinProperties != nil {
-		minProps := int64(*js.MinProperties)
-		s.MinProperties = &minProps
-	}
-	if js.MaxProperties != nil {
-		maxProps := int64(*js.MaxProperties)
-		s.MaxProperties = &maxProps
-	}
 	if js.Properties != nil && js.Properties.Len() > 0 {
 		s.Properties = make(map[string]*Schema)
 		s.PropertyOrdering = make([]string, 0, js.Properties.Len())

--- a/chat_complete_test.go
+++ b/chat_complete_test.go
@@ -52,23 +52,6 @@ func TestGenerateSchema(t *testing.T) {
 		is.Equal(t, *heightSchema.Maximum, 3.0)
 	})
 
-	t.Run("string with constraints", func(t *testing.T) {
-		type StringConstraints struct {
-			Username string `json:"username" jsonschema:"minLength=3,maxLength=20,pattern=^[a-zA-Z0-9_]+$"`
-		}
-
-		schema := gai.GenerateSchema[StringConstraints]()
-
-		usernameSchema := schema.Properties["username"]
-		is.NotNil(t, usernameSchema)
-		is.Equal(t, usernameSchema.Type, gai.SchemaTypeString)
-		is.NotNil(t, usernameSchema.MinLength)
-		is.Equal(t, *usernameSchema.MinLength, int64(3))
-		is.NotNil(t, usernameSchema.MaxLength)
-		is.Equal(t, *usernameSchema.MaxLength, int64(20))
-		is.Equal(t, usernameSchema.Pattern, "^[a-zA-Z0-9_]+$")
-	})
-
 	t.Run("enum field", func(t *testing.T) {
 		type EnumField struct {
 			Status string `json:"status" jsonschema:"enum=active,enum=inactive,enum=pending"`


### PR DESCRIPTION
Let's keep it simple(r).

See #104 and see #82