### PR TITLE
Make OpenAI and Google `Embedder` generic over `gai.VectorComponent`

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ func TestEvalSeagull(t *testing.T) {
 		Model: openai.ChatCompleteModelGPT4o,
 	})
 
-	embedder := c.NewEmbedder(openai.NewEmbedderOptions{
+	embedder := openai.NewEmbedder[float64](c, openai.NewEmbedderOptions{
 		Dimensions: 1536,
 		Model:      openai.EmbedModelTextEmbedding3Small,
 	})
@@ -425,7 +425,7 @@ func TestEvalImageDescription(t *testing.T) {
 		})
 
 		// Use the multimodal embedder for semantic similarity scoring.
-		embedder := gc.NewEmbedder(google.NewEmbedderOptions{
+		embedder := google.NewEmbedder[float32](gc, google.NewEmbedderOptions{
 			Model:      google.EmbedModelGeminiEmbedding2Preview,
 			Dimensions: 768,
 		})

--- a/clients/google/embed.go
+++ b/clients/google/embed.go
@@ -22,8 +22,9 @@ const (
 	EmbedModelGeminiEmbedding2Preview = EmbedModel("gemini-embedding-2-preview")
 )
 
-// Embedder satisfies [gai.Embedder] for Google Gemini models.
-type Embedder struct {
+// Embedder satisfies [gai.Embedder] for Google Gemini embedding models.
+// T picks the vector component type; typical choices are float32 or float64.
+type Embedder[T gai.VectorComponent] struct {
 	Client     *genai.Client
 	dimensions int
 	log        *slog.Logger
@@ -31,14 +32,16 @@ type Embedder struct {
 	tracer     trace.Tracer
 }
 
-// NewEmbedderOptions for [Client.NewEmbedder].
+// NewEmbedderOptions for [NewEmbedder].
 type NewEmbedderOptions struct {
 	Dimensions int
 	Model      EmbedModel
 }
 
-// NewEmbedder creates a new [Embedder].
-func (c *Client) NewEmbedder(opts NewEmbedderOptions) *Embedder {
+// NewEmbedder returns a new [Embedder] with the given vector component type T.
+// This is a package-level function rather than a method on [Client] because Go
+// does not permit type parameters on methods. Example: google.NewEmbedder[float32](c, opts).
+func NewEmbedder[T gai.VectorComponent](c *Client, opts NewEmbedderOptions) *Embedder[T] {
 	if opts.Dimensions <= 0 {
 		panic("dimensions must be greater than 0")
 	}
@@ -47,7 +50,7 @@ func (c *Client) NewEmbedder(opts NewEmbedderOptions) *Embedder {
 		panic("dimensions must be less than or equal to 3072")
 	}
 
-	return &Embedder{
+	return &Embedder[T]{
 		Client:     c.Client,
 		dimensions: opts.Dimensions,
 		log:        c.log,
@@ -57,7 +60,7 @@ func (c *Client) NewEmbedder(opts NewEmbedderOptions) *Embedder {
 }
 
 // Embed satisfies [gai.Embedder].
-func (e *Embedder) Embed(ctx context.Context, req gai.EmbedRequest) (gai.EmbedResponse[float32], error) {
+func (e *Embedder[T]) Embed(ctx context.Context, req gai.EmbedRequest) (gai.EmbedResponse[T], error) {
 	ctx, span := e.tracer.Start(ctx, "google.embed",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
@@ -97,18 +100,21 @@ func (e *Embedder) Embed(ctx context.Context, req gai.EmbedRequest) (gai.EmbedRe
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "embedding request failed")
-		return gai.EmbedResponse[float32]{}, errors.Wrap(err, "error embedding")
+		return gai.EmbedResponse[T]{}, errors.Wrap(err, "error embedding")
 	}
 	if len(res.Embeddings) == 0 {
 		err := errors.New("no embeddings returned")
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "no embeddings in response")
-		return gai.EmbedResponse[float32]{}, err
+		return gai.EmbedResponse[T]{}, err
 	}
 
-	return gai.EmbedResponse[float32]{
-		Embedding: res.Embeddings[0].Values,
+	values := res.Embeddings[0].Values
+	embedding := make([]T, len(values))
+	for i, c := range values {
+		embedding[i] = T(c)
+	}
+	return gai.EmbedResponse[T]{
+		Embedding: embedding,
 	}, nil
 }
-
-var _ gai.Embedder[float32] = (*Embedder)(nil)

--- a/clients/google/embed_test.go
+++ b/clients/google/embed_test.go
@@ -10,10 +10,24 @@ import (
 )
 
 func TestEmbedder_Embed(t *testing.T) {
-	t.Run("can embed a text", func(t *testing.T) {
+	t.Run("can embed a text as float32", func(t *testing.T) {
 		c := newClient(t)
 
-		e := c.NewEmbedder(google.NewEmbedderOptions{
+		e := google.NewEmbedder[float32](c, google.NewEmbedderOptions{
+			Model:      google.EmbedModelGeminiEmbedding001,
+			Dimensions: 768,
+		})
+
+		res, err := e.Embed(t.Context(), gai.NewTextEmbedRequest("Embed this, please."))
+		is.NotError(t, err)
+
+		is.Equal(t, 768, len(res.Embedding))
+	})
+
+	t.Run("can embed a text as float64 for callers that want wider components", func(t *testing.T) {
+		c := newClient(t)
+
+		e := google.NewEmbedder[float64](c, google.NewEmbedderOptions{
 			Model:      google.EmbedModelGeminiEmbedding001,
 			Dimensions: 768,
 		})
@@ -27,7 +41,7 @@ func TestEmbedder_Embed(t *testing.T) {
 	t.Run("panics with no parts", func(t *testing.T) {
 		c := newClient(t)
 
-		e := c.NewEmbedder(google.NewEmbedderOptions{
+		e := google.NewEmbedder[float32](c, google.NewEmbedderOptions{
 			Model:      google.EmbedModelGeminiEmbedding001,
 			Dimensions: 768,
 		})
@@ -43,7 +57,7 @@ func TestEmbedder_Embed(t *testing.T) {
 	t.Run("panics with unsupported part type", func(t *testing.T) {
 		c := newClient(t)
 
-		e := c.NewEmbedder(google.NewEmbedderOptions{
+		e := google.NewEmbedder[float32](c, google.NewEmbedderOptions{
 			Model:      google.EmbedModelGeminiEmbedding001,
 			Dimensions: 768,
 		})
@@ -61,7 +75,7 @@ func TestEmbedder_Embed(t *testing.T) {
 	t.Run("can embed an image", func(t *testing.T) {
 		c := newClient(t)
 
-		e := c.NewEmbedder(google.NewEmbedderOptions{
+		e := google.NewEmbedder[float32](c, google.NewEmbedderOptions{
 			Model:      google.EmbedModelGeminiEmbedding2Preview,
 			Dimensions: 768,
 		})
@@ -79,7 +93,7 @@ func TestEmbedder_Embed(t *testing.T) {
 	t.Run("can embed audio", func(t *testing.T) {
 		c := newClient(t)
 
-		e := c.NewEmbedder(google.NewEmbedderOptions{
+		e := google.NewEmbedder[float32](c, google.NewEmbedderOptions{
 			Model:      google.EmbedModelGeminiEmbedding2Preview,
 			Dimensions: 768,
 		})
@@ -97,7 +111,7 @@ func TestEmbedder_Embed(t *testing.T) {
 	t.Run("can embed video", func(t *testing.T) {
 		c := newClient(t)
 
-		e := c.NewEmbedder(google.NewEmbedderOptions{
+		e := google.NewEmbedder[float32](c, google.NewEmbedderOptions{
 			Model:      google.EmbedModelGeminiEmbedding2Preview,
 			Dimensions: 768,
 		})
@@ -115,7 +129,7 @@ func TestEmbedder_Embed(t *testing.T) {
 	t.Run("can embed a text with Vertex AI backend", func(t *testing.T) {
 		c := newVertexAIClient(t)
 
-		e := c.NewEmbedder(google.NewEmbedderOptions{
+		e := google.NewEmbedder[float32](c, google.NewEmbedderOptions{
 			Model:      google.EmbedModelGeminiEmbedding001,
 			Dimensions: 768,
 		})
@@ -129,7 +143,7 @@ func TestEmbedder_Embed(t *testing.T) {
 	t.Run("can embed a mixture of text, image, audio, and video", func(t *testing.T) {
 		c := newClient(t)
 
-		e := c.NewEmbedder(google.NewEmbedderOptions{
+		e := google.NewEmbedder[float32](c, google.NewEmbedderOptions{
 			Model:      google.EmbedModelGeminiEmbedding2Preview,
 			Dimensions: 768,
 		})

--- a/clients/google/spans_test.go
+++ b/clients/google/spans_test.go
@@ -37,7 +37,7 @@ func TestEmbedder_Spans(t *testing.T) {
 	t.Run("records standard attributes on the embed span", func(t *testing.T) {
 		sr := oteltest.NewSpanRecorder(t)
 		c := newClient(t)
-		e := c.NewEmbedder(google.NewEmbedderOptions{
+		e := google.NewEmbedder[float32](c, google.NewEmbedderOptions{
 			Model:      google.EmbedModelGeminiEmbedding001,
 			Dimensions: 768,
 		})

--- a/clients/openai/embed.go
+++ b/clients/openai/embed.go
@@ -21,7 +21,9 @@ const (
 	EmbedModelTextEmbedding3Small = EmbedModel(openai.EmbeddingModelTextEmbedding3Small)
 )
 
-type Embedder struct {
+// Embedder satisfies [gai.Embedder] for OpenAI embedding models.
+// T picks the vector component type; typical choices are float32 or float64.
+type Embedder[T gai.VectorComponent] struct {
 	Client     openai.Client
 	dimensions int
 	log        *slog.Logger
@@ -29,12 +31,16 @@ type Embedder struct {
 	tracer     trace.Tracer
 }
 
+// NewEmbedderOptions for [NewEmbedder].
 type NewEmbedderOptions struct {
 	Dimensions int
 	Model      EmbedModel
 }
 
-func (c *Client) NewEmbedder(opts NewEmbedderOptions) *Embedder {
+// NewEmbedder returns a new [Embedder] with the given vector component type T.
+// This is a package-level function rather than a method on [Client] because Go
+// does not permit type parameters on methods. Example: openai.NewEmbedder[float32](c, opts).
+func NewEmbedder[T gai.VectorComponent](c *Client, opts NewEmbedderOptions) *Embedder[T] {
 	if opts.Dimensions <= 0 {
 		panic("dimensions must be greater than 0")
 	}
@@ -50,7 +56,7 @@ func (c *Client) NewEmbedder(opts NewEmbedderOptions) *Embedder {
 		}
 	}
 
-	return &Embedder{
+	return &Embedder[T]{
 		Client:     c.Client,
 		dimensions: opts.Dimensions,
 		log:        c.log,
@@ -60,7 +66,7 @@ func (c *Client) NewEmbedder(opts NewEmbedderOptions) *Embedder {
 }
 
 // Embed satisfies [gai.Embedder].
-func (e *Embedder) Embed(ctx context.Context, req gai.EmbedRequest) (gai.EmbedResponse[float64], error) {
+func (e *Embedder[T]) Embed(ctx context.Context, req gai.EmbedRequest) (gai.EmbedResponse[T], error) {
 	ctx, span := e.tracer.Start(ctx, "openai.embed",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
@@ -89,13 +95,13 @@ func (e *Embedder) Embed(ctx context.Context, req gai.EmbedRequest) (gai.EmbedRe
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "embedding request failed")
-		return gai.EmbedResponse[float64]{}, errors.Wrap(err, "error embedding")
+		return gai.EmbedResponse[T]{}, errors.Wrap(err, "error embedding")
 	}
 	if len(res.Data) == 0 {
 		err := errors.New("no embeddings returned")
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "no embeddings in response")
-		return gai.EmbedResponse[float64]{}, err
+		return gai.EmbedResponse[T]{}, err
 	}
 
 	// Record token usage if available
@@ -106,9 +112,11 @@ func (e *Embedder) Embed(ctx context.Context, req gai.EmbedRequest) (gai.EmbedRe
 		)
 	}
 
-	return gai.EmbedResponse[float64]{
-		Embedding: res.Data[0].Embedding,
+	embedding := make([]T, len(res.Data[0].Embedding))
+	for i, c := range res.Data[0].Embedding {
+		embedding[i] = T(c)
+	}
+	return gai.EmbedResponse[T]{
+		Embedding: embedding,
 	}, nil
 }
-
-var _ gai.Embedder[float64] = (*Embedder)(nil)

--- a/clients/openai/embed_test.go
+++ b/clients/openai/embed_test.go
@@ -10,10 +10,24 @@ import (
 )
 
 func TestEmbedder_Embed(t *testing.T) {
-	t.Run("can embed a text", func(t *testing.T) {
+	t.Run("can embed a text as float64", func(t *testing.T) {
 		c := newClient(t)
 
-		e := c.NewEmbedder(openai.NewEmbedderOptions{
+		e := openai.NewEmbedder[float64](c, openai.NewEmbedderOptions{
+			Model:      openai.EmbedModelTextEmbedding3Small,
+			Dimensions: 1536,
+		})
+
+		res, err := e.Embed(t.Context(), gai.NewTextEmbedRequest("Embed this, please."))
+		is.NotError(t, err)
+
+		is.Equal(t, 1536, len(res.Embedding))
+	})
+
+	t.Run("can embed a text as float32 for vector stores that want narrower components", func(t *testing.T) {
+		c := newClient(t)
+
+		e := openai.NewEmbedder[float32](c, openai.NewEmbedderOptions{
 			Model:      openai.EmbedModelTextEmbedding3Small,
 			Dimensions: 1536,
 		})
@@ -27,7 +41,7 @@ func TestEmbedder_Embed(t *testing.T) {
 	t.Run("panics with no parts", func(t *testing.T) {
 		c := newClient(t)
 
-		e := c.NewEmbedder(openai.NewEmbedderOptions{
+		e := openai.NewEmbedder[float64](c, openai.NewEmbedderOptions{
 			Model:      openai.EmbedModelTextEmbedding3Small,
 			Dimensions: 1536,
 		})
@@ -43,7 +57,7 @@ func TestEmbedder_Embed(t *testing.T) {
 	t.Run("panics with a non-text part", func(t *testing.T) {
 		c := newClient(t)
 
-		e := c.NewEmbedder(openai.NewEmbedderOptions{
+		e := openai.NewEmbedder[float64](c, openai.NewEmbedderOptions{
 			Model:      openai.EmbedModelTextEmbedding3Small,
 			Dimensions: 1536,
 		})
@@ -61,7 +75,7 @@ func TestEmbedder_Embed(t *testing.T) {
 	t.Run("panics with multiple parts", func(t *testing.T) {
 		c := newClient(t)
 
-		e := c.NewEmbedder(openai.NewEmbedderOptions{
+		e := openai.NewEmbedder[float64](c, openai.NewEmbedderOptions{
 			Model:      openai.EmbedModelTextEmbedding3Small,
 			Dimensions: 1536,
 		})

--- a/clients/openai/spans_test.go
+++ b/clients/openai/spans_test.go
@@ -38,7 +38,7 @@ func TestEmbedder_Spans(t *testing.T) {
 	t.Run("records standard attributes on the embed span", func(t *testing.T) {
 		sr := oteltest.NewSpanRecorder(t)
 		c := newClient(t)
-		e := c.NewEmbedder(openai.NewEmbedderOptions{
+		e := openai.NewEmbedder[float64](c, openai.NewEmbedderOptions{
 			Model:      openai.EmbedModelTextEmbedding3Small,
 			Dimensions: 1536,
 		})

--- a/internal/examples/evals/evals_test.go
+++ b/internal/examples/evals/evals_test.go
@@ -25,7 +25,7 @@ func TestEvalSeagull(t *testing.T) {
 		Model: openai.ChatCompleteModelGPT4o,
 	})
 
-	embedder := c.NewEmbedder(openai.NewEmbedderOptions{
+	embedder := openai.NewEmbedder[float64](c, openai.NewEmbedderOptions{
 		Dimensions: 1536,
 		Model:      openai.EmbedModelTextEmbedding3Small,
 	})
@@ -77,7 +77,7 @@ func TestEvalImageDescription(t *testing.T) {
 			Model: google.ChatCompleteModelGemini2_5Flash,
 		})
 
-		embedder := gc.NewEmbedder(google.NewEmbedderOptions{
+		embedder := google.NewEmbedder[float32](gc, google.NewEmbedderOptions{
 			Model:      google.EmbedModelGeminiEmbedding2Preview,
 			Dimensions: 768,
 		})

--- a/internal/examples/robust_embed/main.go
+++ b/internal/examples/robust_embed/main.go
@@ -4,9 +4,8 @@
 // 401 → retry → fallback → exhaustion path end to end so it's a useful smoke test
 // of the failover behavior without any setup.
 //
-// Google's embedder returns float32 and OpenAI returns float64, so the two clients
-// can't share a [gai.Embedder[T]] list directly. The googleFloat64 adapter below
-// shows how to bridge the gap by converting float32 components to float64.
+// Both concrete embedders are generic over the vector component type, so picking the
+// same T for both lets them share a [gai.Embedder[T]] list directly, no adapters.
 package main
 
 import (
@@ -25,9 +24,9 @@ func main() {
 	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 	// Key intentionally empty — see top-of-file comment.
-	primary := openai.NewClient(openai.NewClientOptions{
+	primary := openai.NewEmbedder[float32](openai.NewClient(openai.NewClientOptions{
 		Log: log,
-	}).NewEmbedder(openai.NewEmbedderOptions{
+	}), openai.NewEmbedderOptions{
 		Model:      openai.EmbedModelTextEmbedding3Small,
 		Dimensions: 1536,
 	})
@@ -35,16 +34,16 @@ func main() {
 	// Key is a placeholder on purpose — see top-of-file comment. Google's client panics
 	// on an empty key at construction, so we pass a non-empty stub that will fail at
 	// the API call.
-	secondary := google.NewClient(google.NewClientOptions{
+	secondary := google.NewEmbedder[float32](google.NewClient(google.NewClientOptions{
 		Key: "placeholder",
 		Log: log,
-	}).NewEmbedder(google.NewEmbedderOptions{
+	}), google.NewEmbedderOptions{
 		Model:      google.EmbedModelGeminiEmbedding001,
 		Dimensions: 1536,
 	})
 
-	e := robust.NewEmbedder[float64](robust.NewEmbedderOptions[float64]{
-		Embedders:   []gai.Embedder[float64]{primary, googleFloat64{secondary}},
+	e := robust.NewEmbedder[float32](robust.NewEmbedderOptions[float32]{
+		Embedders:   []gai.Embedder[float32]{primary, secondary},
 		MaxAttempts: 3,
 		Log:         log,
 	})
@@ -53,23 +52,4 @@ func main() {
 		log.Error("embedding", "error", err)
 		return
 	}
-}
-
-// googleFloat64 adapts a gai.Embedder[float32] to a gai.Embedder[float64] by converting
-// each component. Use when you need cross-provider fallback and the providers disagree
-// on vector component type.
-type googleFloat64 struct {
-	inner gai.Embedder[float32]
-}
-
-func (g googleFloat64) Embed(ctx context.Context, req gai.EmbedRequest) (gai.EmbedResponse[float64], error) {
-	res, err := g.inner.Embed(ctx, req)
-	if err != nil {
-		return gai.EmbedResponse[float64]{}, err
-	}
-	embedding := make([]float64, len(res.Embedding))
-	for i, v := range res.Embedding {
-		embedding[i] = float64(v)
-	}
-	return gai.EmbedResponse[float64]{Embedding: embedding}, nil
 }


### PR DESCRIPTION
## Summary

- `gai.Embedder[T]` has always been generic, but the concrete `openai.Embedder` was pinned to `float64` and `google.Embedder` to `float32`. That made cross-provider fallback behind a single `gai.Embedder[T]` awkward (see the `googleFloat64` adapter the `robust_embed` example used to need) and forced callers targeting a `float32` store like `sqlite-vec` to copy-convert on every call.
- Both concrete embedders now take `T gai.VectorComponent`. Since Go methods cannot introduce their own type parameters, `NewEmbedder` moves from a method on `*Client` to a package-level function: `openai.NewEmbedder[float32](c, opts)` / `google.NewEmbedder[float64](c, opts)`.
- Conversion from the SDK's native component type into `[]T` happens once inside each client instead of at every caller. The `internal/examples/robust_embed` sample drops its `googleFloat64` adapter — both sides now just pick the same `T`.

## Breaking changes

- `(*openai.Client).NewEmbedder(opts)` → `openai.NewEmbedder[T](c, opts)`
- `(*google.Client).NewEmbedder(opts)` → `google.NewEmbedder[T](c, opts)`

README, `internal/examples/evals`, and `internal/examples/robust_embed` are updated to the new shape.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -shuffle on ./clients/openai ./clients/google ./robust ./eval` (Vertex subtest skipped; missing `GOOGLE_VERTEX_KEY` is a pre-existing env requirement)
- [x] New `TestEmbedder_Embed` subtests exercise both `float32` and `float64` for each client

Fixes #234